### PR TITLE
Add PostgreSQL database configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,7 @@ class Blockchain:
 # Creating the Web 
 # App using flask 
 app = Flask(__name__) 
-app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///default.db')
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['DATABASE_URL']
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)

--- a/app.py
+++ b/app.py
@@ -15,7 +15,9 @@ import json
 # Flask is for creating the web 
 # app and jsonify is for 
 # displaying the blockchain 
+import os
 from flask import Flask, jsonify, render_template, url_for
+from flask_sqlalchemy import SQLAlchemy
   
   
 class Blockchain: 
@@ -87,6 +89,10 @@ class Blockchain:
 # Creating the Web 
 # App using flask 
 app = Flask(__name__) 
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///default.db')
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
   
 # Create the object 
 # of the class blockchain 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,21 +16,21 @@ services:
     # Set environment variables (e.g., for Flask or database connection)
     environment:
       FLASK_ENV: development # Set Flask to development mode (optional)
-      # DATABASE_URL: postgresql://user:password@db:5432/mydatabase # Example for a future database
+      DATABASE_URL: postgresql://user:password@db:5432/mydatabase # Example for a future database
     # Command to run your Flask application using Gunicorn
     # This overrides the CMD in the Dockerfile if present, but for Gunicorn, it's consistent.
     command: gunicorn --bind 0.0.0.0:5000 app:app # Make sure 'app:app' matches your Flask app instance
 
   # Example of a future database service (currently commented out)
-  # db:
-  #   image: postgres:13-alpine # Use a lightweight PostgreSQL image
-  #   environment:
-  #     POSTGRES_DB: mydatabase
-  #     POSTGRES_USER: user
-  #     POSTGRES_PASSWORD: password
-  #   volumes:
-  #     - db_data:/var/lib/postgresql/data # Persist database data
-  #   restart: always # Always restart if it stops
+  db:
+    image: postgres:13-alpine # Use a lightweight PostgreSQL image
+    environment:
+      POSTGRES_DB: mydatabase
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/postgresql/data # Persist database data
+    restart: always # Always restart if it stops
 
 # Define volumes for data persistence (e.g., for databases)
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,18 +16,18 @@ services:
     # Set environment variables (e.g., for Flask or database connection)
     environment:
       FLASK_ENV: development # Set Flask to development mode (optional)
-      DATABASE_URL: postgresql://user:password@db:5432/mydatabase # Example for a future database
+      DATABASE_URL: ${DATABASE_URL}
     # Command to run your Flask application using Gunicorn
     # This overrides the CMD in the Dockerfile if present, but for Gunicorn, it's consistent.
     command: gunicorn --bind 0.0.0.0:5000 app:app # Make sure 'app:app' matches your Flask app instance
 
   # Example of a future database service (currently commented out)
   db:
-    image: postgres:13-alpine # Use a lightweight PostgreSQL image
+    image: postgres:16-alpine # Use a lightweight PostgreSQL image
     environment:
-      POSTGRES_DB: mydatabase
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - db_data:/var/lib/postgresql/data # Persist database data
     restart: always # Always restart if it stops

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 packaging==25.0
 Werkzeug==3.1.3
+Flask-SQLAlchemy==3.1.1
+psycopg2-binary==2.9.10


### PR DESCRIPTION
This PR adds PostgreSQL database configuration by uncommenting the PostgreSQL service in docker-compose.yml, adding the necessary dependencies to requirements.txt, and configuring the Flask app to use SQLAlchemy.

---
*PR created automatically by Jules for task [6749701193447250092](https://jules.google.com/task/6749701193447250092) started by @anubhavsingh244*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable PostgreSQL with SQLAlchemy. Adds a Postgres `db` service in `docker-compose` and configures the Flask app to use `DATABASE_URL`.

- **Dependencies**
  - Added `Flask-SQLAlchemy`
  - Added `psycopg2-binary`

- **Migration**
  - Use `docker-compose up` with `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `DATABASE_URL` set
  - If running locally without Docker, set `DATABASE_URL=postgresql://user:password@localhost:5432/mydatabase`

<sup>Written for commit f56d25cfc8895e5f50f360ce479800e2f6bd1999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured application to use an external relational database and updated initialization to enable ORM-backed persistence.
  * Enabled a managed PostgreSQL service for local deployment with persistent storage and restart behavior.

* **Dependencies**
  * Added database client and ORM packages (Flask-SQLAlchemy, psycopg2-binary).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->