### PR TITLE
🔒 Fix Security Vulnerability: Change FLASK_ENV to production in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - .:/app
     # Set environment variables (e.g., for Flask or database connection)
     environment:
-      FLASK_ENV: development # Set Flask to development mode (optional)
+      FLASK_ENV: production # Set Flask environment to production
       # DATABASE_URL: postgresql://user:password@db:5432/mydatabase # Example for a future database
     # Command to run your Flask application using Gunicorn
     # This overrides the CMD in the Dockerfile if present, but for Gunicorn, it's consistent.


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Changed `FLASK_ENV` from `development` to `production` in `docker-compose.yml`.

⚠️ **Risk:** The potential impact if left unfixed
Running Flask in development mode exposes debugging information and tools, which can lead to information disclosure or remote code execution if accessed by unauthorized users.

🛡️ **Solution:** How the fix addresses the vulnerability
By setting the environment to `production`, we disable these development features and ensure the application runs securely.

---
*PR created automatically by Jules for task [17921250681442112212](https://jules.google.com/task/17921250681442112212) started by @anubhavsingh244*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `FLASK_ENV` to `production` in `docker-compose.yml` to disable Flask debug tools and harden the app by default. This addresses a security risk where containers could run in development mode with the debugger and reloader exposed.

<sup>Written for commit a4a5eaaf1dda8d97e0cbc4c701a217b30d3b4cd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

