### PR TITLE
🧪 Add unit tests for Blockchain.proof_of_work

### DIFF
--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -1,0 +1,43 @@
+import sys
+import hashlib
+from unittest.mock import MagicMock
+
+# Mock flask module completely
+flask_mock = MagicMock()
+
+class MockApp:
+    def route(self, *args, **kwargs):
+        def decorator(f):
+            return f
+        return decorator
+    def run(self, *args, **kwargs):
+        pass
+
+flask_mock.Flask = lambda name: MockApp()
+flask_mock.jsonify = lambda x: x
+flask_mock.render_template = lambda *args, **kwargs: ""
+flask_mock.url_for = lambda *args, **kwargs: ""
+
+sys.modules['flask'] = flask_mock
+
+from app import Blockchain
+
+def test_proof_of_work_basic():
+    """Test proof of work with the initial block's proof."""
+    blockchain = Blockchain()
+    previous_proof = 1
+    new_proof = blockchain.proof_of_work(previous_proof)
+
+    # Verify the proof generates a valid hash
+    hash_operation = hashlib.sha256(str(new_proof**2 - previous_proof**2).encode()).hexdigest()
+    assert hash_operation[:5] == '00000'
+
+def test_proof_of_work_different_previous():
+    """Test proof of work with an arbitrary previous proof."""
+    blockchain = Blockchain()
+    previous_proof = 533
+    new_proof = blockchain.proof_of_work(previous_proof)
+
+    # Verify the proof generates a valid hash
+    hash_operation = hashlib.sha256(str(new_proof**2 - previous_proof**2).encode()).hexdigest()
+    assert hash_operation[:5] == '00000'


### PR DESCRIPTION
🎯 **What:** This PR addresses the testing gap for `Blockchain.proof_of_work` in `app.py`.
📊 **Coverage:** The new tests cover:
- Proof generation starting from the initial block's proof.
- Proof generation from an arbitrary previous proof.
- Validates that the newly generated proof produces a valid hash starting with `'00000'` using the prescribed mathematical formula.
✨ **Result:** Test coverage for the core blockchain logic is increased, providing a reliable test double configuration for the `Blockchain` class independent of the Flask server setup.

---
*PR created automatically by Jules for task [12305227875596036051](https://jules.google.com/task/12305227875596036051) started by @anubhavsingh244*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for Blockchain.proof_of_work to validate the proof search and improve coverage. Tests check proofs from the initial block and an arbitrary previous proof, confirm the SHA-256 of new_proof^2 - previous_proof^2 starts with '00000', and run isolated by mocking `flask`.

<sup>Written for commit 33de4ddc43120248f4cc9058095c23a26b05f05d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

