### PR TITLE
🧪 Add tests for Blockchain.create_block

### DIFF
--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -1,0 +1,68 @@
+import sys
+import datetime
+from unittest.mock import MagicMock
+
+# Mock flask because it's not installed in the isolated environment where pytest runs
+flask_mock = MagicMock()
+def route_mock(*args, **kwargs):
+    def decorator(f):
+        return f
+    return decorator
+
+flask_mock.Flask.return_value.route = route_mock
+flask_mock.jsonify = lambda x: x
+flask_mock.render_template = lambda *args, **kwargs: ""
+flask_mock.url_for = lambda *args, **kwargs: ""
+
+sys.modules['flask'] = flask_mock
+
+from app import Blockchain
+
+def test_create_block_increases_length():
+    """Test that creating a block increases the chain length."""
+    b = Blockchain()
+    initial_length = len(b.chain)
+
+    b.create_block(proof=100, previous_hash='abc123def')
+
+    assert len(b.chain) == initial_length + 1
+
+def test_create_block_attributes():
+    """Test that the block created has the correct attributes."""
+    b = Blockchain()
+
+    # create_block is already called once in __init__ (genesis block)
+    block = b.create_block(proof=123, previous_hash='some_hash')
+
+    assert block['index'] == 2
+    assert block['proof'] == 123
+    assert block['previous_hash'] == 'some_hash'
+
+    # check that timestamp is valid
+    try:
+        datetime.datetime.strptime(block['timestamp'], '%Y-%m-%d %H:%M:%S.%f')
+    except ValueError:
+        # Some platforms might not have microseconds if it's exact, fallback
+        try:
+            datetime.datetime.strptime(block['timestamp'], '%Y-%m-%d %H:%M:%S')
+        except ValueError:
+            assert False, f"Invalid timestamp format: {block['timestamp']}"
+
+    assert b.chain[-1] == block
+
+def test_create_multiple_blocks():
+    """Test creating multiple blocks successively."""
+    b = Blockchain()
+
+    b.create_block(proof=10, previous_hash='hash1')
+    b.create_block(proof=20, previous_hash='hash2')
+    b.create_block(proof=30, previous_hash='hash3')
+
+    assert len(b.chain) == 4  # 1 genesis + 3 new
+    assert b.chain[1]['proof'] == 10
+    assert b.chain[2]['proof'] == 20
+    assert b.chain[3]['proof'] == 30
+
+    assert b.chain[1]['previous_hash'] == 'hash1'
+    assert b.chain[2]['previous_hash'] == 'hash2'
+    assert b.chain[3]['previous_hash'] == 'hash3'

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -1,25 +1,33 @@
 import sys
 import datetime
+import pytest
 from unittest.mock import MagicMock
 
-# Mock flask because it's not installed in the isolated environment where pytest runs
-flask_mock = MagicMock()
-def route_mock(*args, **kwargs):
-    def decorator(f):
-        return f
-    return decorator
+@pytest.fixture(autouse=True)
+def mock_flask(monkeypatch):
+    """Mock flask because it's not installed in the isolated environment where pytest runs."""
+    flask_mock = MagicMock()
+    def route_mock(*args, **kwargs):
+        def decorator(f):
+            return f
+        return decorator
 
-flask_mock.Flask.return_value.route = route_mock
-flask_mock.jsonify = lambda x: x
-flask_mock.render_template = lambda *args, **kwargs: ""
-flask_mock.url_for = lambda *args, **kwargs: ""
+    flask_mock.Flask.return_value.route = route_mock
+    flask_mock.jsonify = lambda x: x
+    flask_mock.render_template = lambda *args, **kwargs: ""
+    flask_mock.url_for = lambda *args, **kwargs: ""
 
-sys.modules['flask'] = flask_mock
+    monkeypatch.setitem(sys.modules, 'flask', flask_mock)
 
-from app import Blockchain
+    # Also we need to import Blockchain inside the test or yield to allow app.py to import the mocked flask
+    # If we import at the top level, it fails because fixture is not yet applied
+    # Let's yield and then the test can import, or better, we just reload the module if necessary.
+    # Actually, importing inside the test function works best to ensure it imports with the mock.
+    yield
 
 def test_create_block_increases_length():
     """Test that creating a block increases the chain length."""
+    from app import Blockchain
     b = Blockchain()
     initial_length = len(b.chain)
 
@@ -29,6 +37,7 @@ def test_create_block_increases_length():
 
 def test_create_block_attributes():
     """Test that the block created has the correct attributes."""
+    from app import Blockchain
     b = Blockchain()
 
     # create_block is already called once in __init__ (genesis block)
@@ -52,6 +61,7 @@ def test_create_block_attributes():
 
 def test_create_multiple_blocks():
     """Test creating multiple blocks successively."""
+    from app import Blockchain
     b = Blockchain()
 
     b.create_block(proof=10, previous_hash='hash1')


### PR DESCRIPTION
🎯 **What:** 
The testing gap addressed is the lack of unit tests for the `Blockchain.create_block` method in `app.py`.

📊 **Coverage:** 
The test suite now covers scenarios such as ensuring that adding a block increments the chain length correctly (`test_create_block_increases_length`), verifying all assigned block attributes including `index`, `proof`, `previous_hash` and formatting of `timestamp` (`test_create_block_attributes`), as well as guaranteeing that sequentially appending multiple blocks works correctly (`test_create_multiple_blocks`).

✨ **Result:** 
By writing deterministic `pytest` tests using mocked `flask` methods (since the testing environment doesn't provide it globally), the tests reliably confirm the correctness of block creation, catching any possible regression bugs if the data model changes.

---
*PR created automatically by Jules for task [4574515172319071624](https://jules.google.com/task/4574515172319071624) started by @anubhavsingh244*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `Blockchain.create_block` to verify chain length increases, block attributes (`index`, `proof`, `previous_hash`, `timestamp`), and sequential block creation. Tests run deterministically with `pytest`, using an autouse `monkeypatch` fixture to mock the `flask` module for environments without Flask.

<sup>Written for commit 506c4275069822b1951c0b86fb9d547324fd14f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

