### PR TITLE
🔒 Fix State-Changing Operation via GET request on /mine_block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ instance/
 
 # Operating System Files
 .DS_Store
-Thumbs.db
+Thumbs.dbapp_output.log

--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def home_page():
     return render_template('index.html')
   
 # Mining a new block 
-@app.route('/mine_block', methods=['GET']) 
+@app.route('/mine_block', methods=['POST'])
 def mine_block(): 
     print('1')
     previous_block = blockchain.print_previous_block() 

--- a/static/js/mine_block.js
+++ b/static/js/mine_block.js
@@ -1,7 +1,7 @@
  // Function to call the '/mine_block' API and display the mined block's details
 
 function mineBlock() {
-    fetch('/mine_block')
+    fetch('/mine_block', { method: 'POST' })
         .then(response => response.json())
         .then(data => {
             console.log(data+'RandomString');
@@ -25,7 +25,7 @@ window.onload = function() {
 /* //Event on ready DOM
 document.addEventListener("DOMContentLoaded", function () {
     //Fetch data
-    fetch('/mine_block')
+    fetch('/mine_block', { method: 'POST' })
         .then((response) => response.json())
         .then((json) => {
             //Then json info is here

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,33 @@
+import pytest
+import json
+from app import app, blockchain
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_mine_block_post(client):
+    # Check the initial chain length
+    initial_length = len(blockchain.chain)
+
+    # Send a POST request to /mine_block
+    response = client.post('/mine_block')
+
+    assert response.status_code == 200
+
+    response_data = json.loads(response.data)
+    assert response_data['message'] == 'A block is MINED'
+    assert 'index' in response_data
+    assert response_data['index'] == initial_length + 1
+
+    # Verify the chain actually grew
+    assert len(blockchain.chain) == initial_length + 1
+
+def test_mine_block_get_not_allowed(client):
+    # Send a GET request to /mine_block
+    response = client.get('/mine_block')
+
+    # Should not be allowed since we changed it to POST only
+    assert response.status_code == 405


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in the `/mine_block` endpoint where state-changing operations were performed via a GET request. Changed the method to POST in both backend (`app.py`) and frontend (`static/js/mine_block.js`).
⚠️ **Risk:** State-changing operations via GET requests are susceptible to CSRF, pre-fetching, and unintended state changes from web crawlers or user navigations.
🛡️ **Solution:** Updated the route `methods` argument to accept only `POST` requests and ensured that the frontend JS fetch call explicitly sets `{ method: 'POST' }`. Unit tests have been added to verify that `POST` requests successfully mine blocks and `GET` requests fail with `405 Method Not Allowed`.

---
*PR created automatically by Jules for task [5286096362976137235](https://jules.google.com/task/5286096362976137235) started by @anubhavsingh244*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the `/mine_block` endpoint by switching from GET to POST to prevent CSRF and accidental triggers. Updated the frontend call and added tests; GET now returns 405.

- **Bug Fixes**
  - Made `/mine_block` POST-only in `app.py`.
  - Updated `static/js/mine_block.js` to call `fetch('/mine_block', { method: 'POST' })`.
  - Added `tests/test_app.py` to verify POST mines a block and GET returns 405.

- **Migration**
  - Update any clients calling `/mine_block` via GET to use POST.

<sup>Written for commit 665217b860049d0fb1beb6377359d4b4552f3473. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

