### PR TITLE
🔒 [security fix] Run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
 # Use a lightweight Python base image
 FROM python:3.9-slim-buster
 
+# Create a non-root user
+RUN useradd -m appuser
+
 # Set the working directory inside the container
 WORKDIR /app
+RUN chown appuser:appuser /app
 
 # Copy only the requirements file first to leverage Docker cache
-COPY requirements.txt .
+COPY --chown=appuser:appuser requirements.txt .
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of your application code
 # This includes app.py, static/, and templates/
-COPY . .
+COPY --chown=appuser:appuser . .
 
 # Expose the port Flask listens on
 EXPOSE 5000
+
+# Switch to the non-root user
+USER appuser
 
 # Command to run the application using Gunicorn (recommended for production)
 # Assuming your Flask app instance is named 'app' in 'app.py'


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The Docker container was previously running as the `root` user, which is a security anti-pattern. If an attacker were to exploit a vulnerability in the Flask application (e.g., an RCE), they would immediately have root privileges within the container.

### ⚠️ Risk: The potential impact if left unfixed
- **Container Escape:** Running as root makes it significantly easier for an attacker to exploit kernel vulnerabilities or misconfigurations to escape the container and gain access to the host system.
- **Privilege Escalation:** An attacker who compromises the application can modify system files, install malicious packages, or access sensitive data within the container that should be protected.
- **Compliance:** Many security standards and best practices (such as CIS benchmarks) require containers to run as non-root users.

### 🛡️ Solution: How the fix addresses the vulnerability
- **User Creation:** A dedicated system user `appuser` is created using `useradd`.
- **Least Privilege:** The application ownership and execution context are switched to this non-root user.
- **Secure File Copying:** The `--chown` flag is used during the `COPY` phase to ensure file ownership is set correctly without creating unnecessary image layers.
- **Runtime Security:** The `USER appuser` directive ensures that the Gunicorn server and the Flask application run with restricted permissions.

---
*PR created automatically by Jules for task [12953366084169294856](https://jules.google.com/task/12953366084169294856) started by @anubhavsingh244*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Docker container as non-root `appuser` to reduce privilege escalation risk and align with container security best practices. Ensures app files are owned by `appuser` and `gunicorn`/`Flask` run under least privilege.

- **Bug Fixes**
  - Created `appuser` and set `/app` ownership.
  - Used `COPY --chown=appuser:appuser` for requirements and app files.
  - Switched runtime to `USER appuser` so `gunicorn` runs as non-root.

<sup>Written for commit a4bb7e3837544dc3e25e9c4013abc6e734cb2422. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

